### PR TITLE
Rename executables

### DIFF
--- a/makefile_game
+++ b/makefile_game
@@ -2,7 +2,7 @@
 # VAR = expands when referenced
 
 # output binary
-BIN := .run/game
+BIN := .run/asciicker
 
 # source files
 # SRCS :=	game_app.cpp \

--- a/makefile_game_term
+++ b/makefile_game_term
@@ -2,7 +2,7 @@
 # VAR = expands when referenced
 
 # output binary
-BIN := .run/game_term
+BIN := .run/asciicker_term
 
 # source files
 SRCS :=	game.cpp \

--- a/makefile_server
+++ b/makefile_server
@@ -2,7 +2,7 @@
 # VAR = expands when referenced
 
 # output binary
-BIN := .run/server
+BIN := .run/asciicker_server
 
 SRCS :=	game_svr.cpp \
 		network.cpp \

--- a/makefile_server_0x
+++ b/makefile_server_0x
@@ -2,7 +2,7 @@
 # VAR = expands when referenced
 
 # output binary
-BIN := .run/server
+BIN := .run/asciicker_server
 
 SRCS :=	game_svr.cpp \
 		network.cpp \

--- a/run_console.sh
+++ b/run_console.sh
@@ -1,2 +1,2 @@
 setfont fonts/cp437_10x10.png.psf
-.run/game_term
+.run/asciicker_term

--- a/run_xterm.sh
+++ b/run_xterm.sh
@@ -12,7 +12,7 @@ xterm \
     -xrm "xterm*font4: -gumix-*-*-*-*-*-16-*-*-*-*-*-*" \
     -xrm "xterm*font5: -gumix-*-*-*-*-*-18-*-*-*-*-*-*" \
     -xrm "xterm*font6: -gumix-*-*-*-*-*-20-*-*-*-*-*-*" \
-    -e .run/game_term 
+    -e .run/asciicker_term 
 
 #cleanup
 xset fp- $PWD/fonts


### PR DESCRIPTION
I changed the name of the output executables to be less generic. Then you can add them to path without worrying about potential clashes.

Note: I did not edit the windows executable names, since I have no clue how to change them